### PR TITLE
Fixed handling of special characters in child process paths

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,11 +81,11 @@ export default async function sea(
   });
   // Generate the blob to be injected
   await spinner_log(`Generating blob into ${preparation_blob_path}`, async () => {
-    await exec(`node --experimental-sea-config ${sea_config_path}`);
+    await exec(`node --experimental-sea-config "${sea_config_path}"`);
   });
   // Inject the blob into the copied binary by running postject
   await spinner_log(`Injecting blob into ${basename(executable_path)}`, async () => {
-    await exec(`npx postject ${executable_path} NODE_SEA_BLOB ${preparation_blob_path} --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2`);
+    await exec(`npx postject "${executable_path}" NODE_SEA_BLOB "${preparation_blob_path}" --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2`);
   });
   // Remove the temporary directory
   await spinner_log(`Removing all the files in temporary directory ${temp_dir}`, async () => {


### PR DESCRIPTION
This PR addresses an issue where paths containing special characters, such as spaces, caused failures during the blob generation and injection processes. The fix ensures that these paths are correctly handled, preventing errors.

## Details

- Modified the `exec` call for blob generation to properly handle paths with special characters:
  ```javascript
  await exec(`node --experimental-sea-config "${sea_config_path}"`);
  ```
- Updated the `exec` call for blob injection to correctly process paths with special characters:
  ```javascript
  await exec(`npx postject "${executable_path}" NODE_SEA_BLOB "${preparation_blob_path}" --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2`);
  ```

## Testing

- Verified that paths containing spaces and other special characters (e.g. /my projects/path/to/my/script) are now processed correctly. ✅
- Ran existing tests to ensure there were no errors.


## Notes
Please review the changes and run the tests to confirm the fix. Your feedback is appreciated.
